### PR TITLE
Another improvement to highligh

### DIFF
--- a/sarna/viz.py
+++ b/sarna/viz.py
@@ -204,6 +204,36 @@ def _check_highlight_var(highlight):
 
 def highlight_bar(x_values, highlight, level=None, height=None, color=None,
                   alpha=1., axis=None):
+    '''Highlight ranges along x axis.
+
+    Parameters
+    ----------
+    x_values : numpy array
+        Values specifying x axis points along which highlight operates.
+    highlight : slice | list of slices | numpy array | list of numpy arrays
+        Slice or boolean numpy array defining which values in ``x_values``
+        should be highlighted. If list of slices or numpy arrays is provided
+        each list element will be used to create a separate highlight.
+    level : float | None
+        Level at which to place the highlight. If ``None`` then the highlight
+        will be placed at the bottom of the axis.
+    height : float | None
+        Height of the highlight. If ``None`` then the highlight will extend to
+        the top of the axis.
+    color : str | list | numpy array, optional
+        Highlight patch color in format understood by matplotlib. The default
+        is ``'orange'``.
+    alpha : float
+        Highlight patch transparency. 0.3 by default.
+    axis : matplotlib Axes | None
+        Highlight on an already present axis. Default is ``None`` which creates
+        a new figure with one axis.
+
+    Returns
+    -------
+    patches : list of matplotlib.patches.Patch
+        List of highlight patches.
+    '''
     from matplotlib.patches import Rectangle
 
     # prepare path args

--- a/sarna/viz.py
+++ b/sarna/viz.py
@@ -143,6 +143,13 @@ def highlight(x_values, highlight, color=None, alpha=1., bottom_bar=False,
     axis : matplotlib Axes | None
         Highlight on an already present axis. Default is ``None`` which creates
         a new figure with one axis.
+
+    Returns
+    -------
+    patches : list of matplotlib.patches.Patch
+        List of highlight patches. If ``bottom_bar`` is ``True`` then each
+        element of the list is a tuple of two patches: the first is the
+        highlight patch and the second is the bottom bar patch.
     '''
 
     axis = plt.gca() if axis is None else axis
@@ -159,15 +166,23 @@ def highlight(x_values, highlight, color=None, alpha=1., bottom_bar=False,
                    else ylims[0] + bar_h / 2)
         patch_low = bar_low + bar_h / 2
 
-    highlight_bar(x_values, grp, level=patch_low, height=None, color=color,
-                  alpha=alpha, axis=axis)
+    patches = highlight_bar(
+        x_values, grp, level=patch_low, height=None, color=color,
+        alpha=alpha, axis=axis
+    )
 
     if bottom_bar:
-        highlight_bar(x_values, grp, level=bar_low, height=bar_h,
-                      color=bar_color, alpha=1., axis=axis)
+        bottom_patches = highlight_bar(
+            x_values, grp, level=bar_low, height=bar_h,
+            color=bar_color, alpha=1., axis=axis
+        )
+        patches = [(main, bottom) for main, bottom in
+                    zip(patches, bottom_patches)]
 
     if bottom_bar and bottom_extend:
         axis.set_ylim((ylims[0] - bar_h, ylims[1]))
+
+    return patches
 
 
 def _check_highlight_var(highlight):
@@ -205,6 +220,7 @@ def highlight_bar(x_values, highlight, level=None, height=None, color=None,
     y_rng = np.diff(ylims)[0]
     x_half_step = np.diff(x_values).mean() / 2
 
+    patches = list()
     level = ylims[0] if level is None else level
     height = y_rng - (ylims[0] - level) if height is None else height
 
@@ -215,6 +231,9 @@ def highlight_bar(x_values, highlight, level=None, height=None, color=None,
 
         patch = Rectangle((start, level), length, height, **args)
         axis.add_patch(patch)
+        patches.append(patch)
+
+    return patches
 
 
 # - [ ] test a little and change the API and options

--- a/sarna/viz.py
+++ b/sarna/viz.py
@@ -115,7 +115,6 @@ def imscatter(x, y, images, ax=None, zoom=1, selection='random'):
     return artists
 
 
-# - [x] support list/tuple of slices for highlight?
 def highlight(x_values=None, highlight=None, color=None, alpha=1., bottom_bar=False,
               bar_color='black', bottom_extend=True, ax=None):
     '''Highlight ranges along x axis.
@@ -225,8 +224,8 @@ def _handle_x_values(ax, x_values):
     return x_values
 
 
-def highlight_bar(x_values, highlight, level=None, height=None, color=None,
-                  alpha=1., ax=None):
+def highlight_bar(x_values=None, highlight=None, level=None, height=None,
+                  color=None, alpha=1., ax=None):
     '''Highlight ranges along x axis.
 
     Parameters
@@ -258,6 +257,8 @@ def highlight_bar(x_values, highlight, level=None, height=None, color=None,
         List of highlight patches.
     '''
     from matplotlib.patches import Rectangle
+
+    x_values = _handle_x_values(ax, x_values)
 
     # prepare path args
     color = [0.95] * 3 if color is None else color

--- a/sarna/viz.py
+++ b/sarna/viz.py
@@ -115,10 +115,11 @@ def imscatter(x, y, images, ax=None, zoom=1, selection='random'):
     return artists
 
 
-# - [ ] support list/tuple of slices for highlight?
+# - [x] support list/tuple of slices for highlight?
 # - [ ] `level` / `height` could allow for highlight that takes only a fraction
 #       of the axis
 #       kind='patch', level=0.04, height=0.03 ?
+#       or maybe even level='5%' ?
 def highlight(x_values, highlight, color=None, alpha=1., bottom_bar=False,
               bottom_extend=True, axis=None):
     '''Highlight ranges along x axis.
@@ -127,15 +128,22 @@ def highlight(x_values, highlight, color=None, alpha=1., bottom_bar=False,
     ----------
     x_values : numpy array
         Values specifying x axis points along which highlight operates.
-    highlight : slice | numpy array
+    highlight : slice | list of slices | numpy array | list of numpy arrays
         Slice or boolean numpy array defining which values in ``x_values``
-        should be highlighted.
+        should be highlighted. If list of slices or numpy arrays is provided
+        each list element will be used to create a separate highlight.
     color : str | list | numpy array, optional
-        Color in format understood by matplotlib. The default is 'orange'.
+        Highlight patch color in format understood by matplotlib. The default
+        is ``'orange'``.
     alpha : float
         Highlight patch transparency. 0.3 by default.
     bottom_bar : bool
-        Whether to place a highlight bar at the bottom of the figure.
+        Whether to place an opaque highlight bar at the bottom of the figure.
+    bar_color : str | list | numpy array, optional
+        Bottom bar color in format understood by matplotlib. The default
+        is ``'black'``.
+    bottom_extend : bool
+        Whether to extend the bottom of the axis before adding the bottom bar.
     axis : matplotlib Axes | None
         Highlight on an already present axis. Default is ``None`` which creates
         a new figure with one axis.
@@ -158,6 +166,9 @@ def highlight(x_values, highlight, color=None, alpha=1., bottom_bar=False,
         grp = group(highlight, return_slice=True)
     elif isinstance(highlight, slice):
         grp = [highlight]
+    else:
+        raise TypeError('highlight must be slice, list of slices, '
+                        'numpy array or list of numpy arrays')
 
     args = dict(lw=0, facecolor=color, alpha=alpha)
     if alpha == 1.:
@@ -180,7 +191,7 @@ def highlight(x_values, highlight, color=None, alpha=1., bottom_bar=False,
 
         if bottom_bar:
             patch = Rectangle((start, bar_low), length, bar_h, lw=0,
-                             facecolor='k', alpha=1.)
+                              facecolor='k', alpha=1.)
             axis.add_patch(patch)
 
     if bottom_bar and bottom_extend:


### PR DESCRIPTION
Add `level` and `height` arguments so that the difference between bottom bar and highlight patch is only a convenience layer. This would:
* disable (or raise warning) when both `bottom_bar=True` and `level` is not None
* lead to calling highlight second time internally with different `level` and `height` (and `alpha`) if `bottom_bar=True`
* allow for much higher flexibility if bottom bars of different colors and at different levels are needed

Soon highlight could be moved to borsar.